### PR TITLE
fix: harden rpc validation thresholds

### DIFF
--- a/core/src/verifiers/solana.rs
+++ b/core/src/verifiers/solana.rs
@@ -55,9 +55,16 @@ impl SolanaVerifier {
         let simulation_config = Self::get_simulation_config();
         let message = deposit_data.get_message(program_id, method_name)?;
         let tx = Transaction::new_unsigned(message);
-        self.client
+        let resp = self
+            .client
             .simulate_transaction_with_config(&tx, simulation_config)
             .await?;
+        if let Some(err) = resp.value.err {
+            return Err(anyhow!(
+                "hot_verify_deposit reverted: {err:?}; logs={:?}",
+                resp.value.logs
+            ));
+        }
         Ok(())
     }
 

--- a/primitives/src/validation.rs
+++ b/primitives/src/validation.rs
@@ -28,6 +28,11 @@ pub struct ChainValidationConfig {
 fn validate_chain_config(
     cfg: &ChainValidationConfig,
 ) -> anyhow::Result<(), serde_valid::validation::Error> {
+    if cfg.threshold == 0 {
+        return Err(serde_valid::validation::Error::Custom(
+            "threshold must be >= 1".to_string(),
+        ));
+    }
     if cfg.servers.len() < cfg.threshold {
         return Err(serde_valid::validation::Error::Custom(format!(
             "Number of servers must be greater than or equal to threshold. Got {} servers and {} threshold.",
@@ -35,5 +40,68 @@ fn validate_chain_config(
             cfg.threshold
         )));
     }
+    // Require a strict majority: any value with fewer than `threshold` matching
+    // votes cannot determine the result. `2 * threshold > servers.len()`
+    // guarantees that at most one variant can ever reach threshold.
+    if cfg.threshold * 2 <= cfg.servers.len() {
+        return Err(serde_valid::validation::Error::Custom(format!(
+            "threshold {} must be strict majority of {} servers (require 2*threshold > servers)",
+            cfg.threshold,
+            cfg.servers.len()
+        )));
+    }
+    for server in &cfg.servers {
+        if !server.starts_with("https://") {
+            return Err(serde_valid::validation::Error::Custom(format!(
+                "plaintext RPC endpoint is not allowed: {server}"
+            )));
+        }
+    }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(threshold: usize, servers: &[&str]) -> ChainValidationConfig {
+        ChainValidationConfig {
+            threshold,
+            servers: servers.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn rejects_zero_threshold() {
+        assert!(validate_chain_config(&cfg(0, &["https://a"])).is_err());
+    }
+
+    #[test]
+    fn rejects_threshold_above_server_count() {
+        assert!(validate_chain_config(&cfg(2, &["https://a"])).is_err());
+    }
+
+    #[test]
+    fn rejects_non_majority_threshold() {
+        // 3-of-7 is a minority — must be rejected
+        let servers: Vec<&str> = (0..7).map(|_| "https://a").collect();
+        assert!(validate_chain_config(&cfg(3, &servers)).is_err());
+        // 3-of-6 is exactly half — also rejected (not *strict* majority)
+        let servers: Vec<&str> = (0..6).map(|_| "https://a").collect();
+        assert!(validate_chain_config(&cfg(3, &servers)).is_err());
+    }
+
+    #[test]
+    fn accepts_strict_majority() {
+        assert!(validate_chain_config(&cfg(1, &["https://a"])).is_ok());
+        assert!(validate_chain_config(&cfg(2, &["https://a", "https://b"])).is_ok());
+        assert!(validate_chain_config(&cfg(2, &["https://a", "https://b", "https://c"])).is_ok());
+        assert!(validate_chain_config(&cfg(3, &["https://a", "https://b", "https://c", "https://d"])).is_ok());
+    }
+
+    #[test]
+    fn rejects_plaintext_endpoint() {
+        assert!(validate_chain_config(&cfg(1, &["http://a"])).is_err());
+        assert!(validate_chain_config(&cfg(2, &["https://a", "http://b"])).is_err());
+    }
 }

--- a/rpc-fetch/src/main.rs
+++ b/rpc-fetch/src/main.rs
@@ -8,7 +8,6 @@ use hot_validation_primitives::{ChainValidationConfig, ExtendedChainId};
 use hot_validation_rpc_healthcheck::healthcheck_many;
 use providers::quicknode::QuicknodeProvider;
 use serde::{Deserialize, Serialize};
-use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
@@ -108,7 +107,11 @@ async fn main() -> Result<()> {
         let mut data = HashMap::new();
         for (chain_id, endpoints) in &mut config {
             let len = endpoints.len();
-            let threshold = if len == 1 { 1 } else { min(len - 1, 3) };
+            if len == 0 {
+                anyhow::bail!("no RPC endpoints for chain {chain_id:?}");
+            }
+            // Strict majority: smallest t such that 2*t > n.
+            let threshold = len / 2 + 1;
             let validation_config = ChainValidationConfig {
                 threshold,
                 servers: endpoints.clone(),


### PR DESCRIPTION
- validation: validate_chain_config now rejects threshold=0, enforces strict majority (2*threshold > servers.len()), and forbids non-https endpoints